### PR TITLE
Updated the README to use the w() method to convert the strings into an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use it in your objects which shall offer the functionality like this, see [JSFid
 ```javascript
 var obj = Ember.Object.create(Ember.Memento, {
     // array of properties which shall be considered in undo/redo
-    mementoProperties: 'firstName lastName age tags',
+    mementoProperties: 'firstName lastName age tags'.w(),
 
     firstName: 'Buster',
     age: 35,


### PR DESCRIPTION
In the README, the example demonstrates the properties using a string, whereas it needs to be converted to an array for it to work correctly.
